### PR TITLE
Add general contract ownership logic (Issue #21)

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -2,7 +2,7 @@ use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IERC404<TContractState> {
-    Fungible Token Functions (ERC20-like)
+    // Fungible Token Functions (ERC20-like)
     fn total_supply(self: @TContractState) -> u256;
     fn balance_of(self: @TContractState, account: ContractAddress) -> u256;
     fn transfer(ref self: TContractState, recipient: ContractAddress, amount: u256) -> bool;
@@ -20,6 +20,8 @@ trait IERC404<TContractState> {
     );
     fn token_uri(self: @TContractState, token_id: u256) -> felt252;
 
+
+    // Admin Functions
     fn set_whitelist(ref self: TContractState, target: ContractAddress, state: bool);
 }
 

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -3,26 +3,30 @@ use starknet::ContractAddress;
 #[starknet::interface]
 trait IERC404<TContractState> {
     // Fungible Token Functions (ERC20-like)
-    fn total_supply(self: @TContractState) -> u256;
-    fn balance_of(self: @TContractState, account: ContractAddress) -> u256;
-    fn transfer(ref self: TContractState, recipient: ContractAddress, amount: u256) -> bool;
-    fn allowance(self: @TContractState, owner: ContractAddress, spender: ContractAddress) -> u256;
-    fn approve(ref self: TContractState, spender: ContractAddress, amount: u256) -> bool;
-    fn transfer_from(ref self: TContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256) -> bool;
+    // fn total_supply(self: @TContractState) -> u256;
+    // fn balance_of(self: @TContractState, account: ContractAddress) -> u256;
+    // fn transfer(ref self: TContractState, recipient: ContractAddress, amount: u256) -> bool;
+    // fn allowance(self: @TContractState, owner: ContractAddress, spender: ContractAddress) -> u256;
+    // fn approve(ref self: TContractState, spender: ContractAddress, amount: u256) -> bool;
+    // fn transfer_from(
+    //     ref self: TContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256
+    // ) -> bool;
 
-    // Non-Fungible Token Functions (ERC721-like)
-    fn owner_of(self: @TContractState, token_id: u256) -> ContractAddress;
-    fn approve_nft(ref self: TContractState, to: ContractAddress, token_id: u256);
-    fn transfer_nft(ref self: TContractState, from: ContractAddress, to: ContractAddress, token_id: u256);
-    fn token_uri(self: @TContractState, token_id: u256) -> felt252;
+    // // Non-Fungible Token Functions (ERC721-like)
+    // fn owner_of(self: @TContractState, token_id: u256) -> ContractAddress;
+    // fn approve_nft(ref self: TContractState, to: ContractAddress, token_id: u256);
+    // fn transfer_nft(
+    //     ref self: TContractState, from: ContractAddress, to: ContractAddress, token_id: u256
+    // );
+    // fn token_uri(self: @TContractState, token_id: u256) -> felt252;
 
     fn set_whitelist(ref self: TContractState, target: ContractAddress, state: bool);
-
 }
 
 #[starknet::contract]
 mod ERC404 {
-    use starknet::get_caller_address;
+    use core::num::traits::zero::Zero;
+use starknet::get_caller_address;
     use starknet::ContractAddress;
 
     #[event]
@@ -60,6 +64,8 @@ mod ERC404 {
         // /// @dev Total supply in fractionalized representation
         // uint256 public immutable totalSupply;
         ERC404_total_supply: u256,
+        // /// @dev Contract Owner
+        ERC404_owner: ContractAddress,
         // /// @dev Current mint counter, monotonically increasing to ensure accurate ownership
         // uint256 public minted;
         ERC404_minted: u256,
@@ -111,6 +117,7 @@ mod ERC404 {
         self.ERC404_decimals.write(_decimals);
         // TODO: Implement POW for 10**_decimals
         self.ERC404_total_supply.write(_totalNativeSupply * (10));
+        self.ERC404_owner.write(_owner);
     }
 
     #[abi(embed_v0)]
@@ -119,8 +126,24 @@ mod ERC404 {
 
         // manage whitelist addresses
         fn set_whitelist(ref self: ContractState, target: ContractAddress, state: bool) {
+            self.assert_only_owner();
             self.ERC404_whitelist.write(target, state);
         }
 
+
+    }
+
+
+    // INTERNAL FUNCTIONS
+    #[generate_trait]
+    impl Internal of InternalTrait {
+
+        // Assert contract owner is calling
+        fn assert_only_owner(self: @ContractState) {
+            let owner = self.ERC404_owner.read();
+            let caller = get_caller_address();
+            assert(caller.is_non_zero(), 'Caller is the zero address');
+            assert(caller == owner, 'Caller is not the owner');
+        }
     }
 }

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -28,7 +28,7 @@ trait IERC404<TContractState> {
 #[starknet::contract]
 mod ERC404 {
     use core::num::traits::zero::Zero;
-use starknet::get_caller_address;
+    use starknet::get_caller_address;
     use starknet::ContractAddress;
 
     #[event]
@@ -131,15 +131,12 @@ use starknet::get_caller_address;
             self.assert_only_owner();
             self.ERC404_whitelist.write(target, state);
         }
-
-
     }
 
 
     // INTERNAL FUNCTIONS
     #[generate_trait]
     impl Internal of InternalTrait {
-
         // Assert contract owner is calling
         fn assert_only_owner(self: @ContractState) {
             let owner = self.ERC404_owner.read();

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -2,23 +2,23 @@ use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IERC404<TContractState> {
-    // Fungible Token Functions (ERC20-like)
-    // fn total_supply(self: @TContractState) -> u256;
-    // fn balance_of(self: @TContractState, account: ContractAddress) -> u256;
-    // fn transfer(ref self: TContractState, recipient: ContractAddress, amount: u256) -> bool;
-    // fn allowance(self: @TContractState, owner: ContractAddress, spender: ContractAddress) -> u256;
-    // fn approve(ref self: TContractState, spender: ContractAddress, amount: u256) -> bool;
-    // fn transfer_from(
-    //     ref self: TContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256
-    // ) -> bool;
+    Fungible Token Functions (ERC20-like)
+    fn total_supply(self: @TContractState) -> u256;
+    fn balance_of(self: @TContractState, account: ContractAddress) -> u256;
+    fn transfer(ref self: TContractState, recipient: ContractAddress, amount: u256) -> bool;
+    fn allowance(self: @TContractState, owner: ContractAddress, spender: ContractAddress) -> u256;
+    fn approve(ref self: TContractState, spender: ContractAddress, amount: u256) -> bool;
+    fn transfer_from(
+        ref self: TContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256
+    ) -> bool;
 
-    // // Non-Fungible Token Functions (ERC721-like)
-    // fn owner_of(self: @TContractState, token_id: u256) -> ContractAddress;
-    // fn approve_nft(ref self: TContractState, to: ContractAddress, token_id: u256);
-    // fn transfer_nft(
-    //     ref self: TContractState, from: ContractAddress, to: ContractAddress, token_id: u256
-    // );
-    // fn token_uri(self: @TContractState, token_id: u256) -> felt252;
+    // Non-Fungible Token Functions (ERC721-like)
+    fn owner_of(self: @TContractState, token_id: u256) -> ContractAddress;
+    fn approve_nft(ref self: TContractState, to: ContractAddress, token_id: u256);
+    fn transfer_nft(
+        ref self: TContractState, from: ContractAddress, to: ContractAddress, token_id: u256
+    );
+    fn token_uri(self: @TContractState, token_id: u256) -> felt252;
 
     fn set_whitelist(ref self: TContractState, target: ContractAddress, state: bool);
 }


### PR DESCRIPTION
Add internal function that asserts that the caller is the owner of the contract.
Can be used as constraint on any external function.